### PR TITLE
Add support for directory uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "funkwhale-cli"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "dialoguer 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "funkwhale-cli"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Rodrigo Leite <rodrigolf.dev@gmail.com>"]
 edition = "2018"
 

--- a/src/funkwhale.rs
+++ b/src/funkwhale.rs
@@ -32,29 +32,37 @@ pub fn get_libraries(instance: &str, token: &str) -> Result<Vec<Library>, Box<st
 }
 
 pub fn upload(files: Vec<std::path::PathBuf>, library: String, instance: String, token: String, timeout: u64) -> Result<(), Box<std::error::Error>> {
-    let filename = &files[0].file_name().unwrap().to_str().unwrap();
     let now = Utc::now();
+    let import_reference = format!("From CLI at {}", now);
+    let url = format!("{}/api/v1/uploads/", instance);
+    let total_files = &files.len();
+    let mut current_file = 0;
 
-    let form = multipart::Form::new()
-        .text("library", library)
-        .text("import_reference", format!("From CLI at {}", now))
-        .text("source", format!("upload://{}", filename))
-        .file("audio_file", &files[0])?;
+    for file in &files {
+        let filename = file.file_name().unwrap().to_str().unwrap();
 
-    let sp = Spinner::new(Spinners::Moon, "Uploading your files. Please wait.".into());
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(timeout))
-        .build()?;
+        let form = multipart::Form::new()
+            .text("library", library.clone())
+            .text("import_reference", import_reference.clone())
+            .text("source", format!("upload://{}", filename))
+            .file("audio_file", file)?;
 
-    let _resp = client
-        .post(&format!("{}/api/v1/uploads/", instance))
-        .bearer_auth(token)
-        .multipart(form)
-        .send()?
-        .text()?;
+        let sp = Spinner::new(Spinners::Moon, "Uploading your files. Please wait.".into());
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(timeout))
+            .build()?;
 
-    sp.message("Uploaded!".into());
-    sp.stop();
+        let _resp = client
+            .post(&url)
+            .bearer_auth(token.clone())
+            .multipart(form)
+            .send()?
+            .text()?;
+
+        sp.message(format!("Uploaded file {} of {}. Uploading...", &current_file + 1, &total_files));
+        sp.stop();
+        current_file += 1;
+    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,8 @@ enum Opt {
         #[structopt(short = "i", long = "interactive")]
         interactive: bool,
 
-        #[structopt(short = "f", long = "files", parse(from_os_str))]
-        files: Vec<std::path::PathBuf>,
+        #[structopt(short = "f", long = "file", parse(from_os_str))]
+        file: std::path::PathBuf,
 
         #[structopt(short = "l", long = "library")]
         library: Option<String>,
@@ -32,12 +32,30 @@ fn parse_token_file(path: std::path::PathBuf) -> String {
     return file.trim().to_string();
 }
 
+fn parse_file(file: std::path::PathBuf) -> Vec<std::path::PathBuf> {
+    if !file.exists() {
+        panic!("File or directory doesn't exist");
+    }
+
+    if file.is_dir() {
+        return std::fs::read_dir(file)
+            .unwrap()
+            .map(|res| res.unwrap().path())
+            .collect();
+    } else {
+        return vec![file];
+    }
+
+}
+
 fn main() {
     let args = Opt::from_args();
 
-    if let Opt::Upload { interactive, files, library, instance_url, token_file, timeout } = args {
+    if let Opt::Upload { interactive, file, library, instance_url, token_file, timeout } = args {
         let token = parse_token_file(token_file);
-        match upload::main(files, library, instance_url, token, interactive, timeout) {
+        let all_files = parse_file(file);
+
+        match upload::main(all_files, library, instance_url, token, interactive, timeout) {
             Ok(v) => println!("\nUpload successful!"),
             Err(e) => panic!("{}", e),
         }


### PR DESCRIPTION
Fixes #1 

Breaks the `-f` option. It now expects either a single file or a directory.